### PR TITLE
Fixing MSVC errors and adding a seed parameter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,10 +57,12 @@ if (NOT DEFAULT_CXX_FLAGS)
     #set(DEFAULT_CXX_FLAGS "-march=native -Wall -fno-math-errno -O3")
 endif()
 
-if (NOT EXTRA_CXX_FLAGS)
-    set(EXTRA_CXX_FLAGS "/Zc:__cplusplus")
-endif()
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEFAULT_CXX_FLAGS} ${EXTRA_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEFAULT_CXX_FLAGS}")
+
+#if (NOT EXTRA_CXX_FLAGS)
+#    set(EXTRA_CXX_FLAGS "/Zc:__cplusplus")
+#endif()
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEFAULT_CXX_FLAGS} ${EXTRA_CXX_FLAGS}")
 
 # Determine executable name
 set(exe pimc.e)
@@ -147,6 +149,10 @@ if(NOT CMAKE_BUILD_TYPE)
    set(CMAKE_BUILD_TYPE None
        CACHE STRING "Choose the type of build : None Debug Release PIGS PIGSDebug."
        FORCE)
+endif()
+
+if ((MSVC) AND (MSVC_VERSION GREATER_EQUAL 1914))
+	target_compile_options(${exe} PUBLIC "/Zc:__cplusplus")
 endif()
 
 # Find Boost

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,11 +59,6 @@ endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEFAULT_CXX_FLAGS}")
 
-#if (NOT EXTRA_CXX_FLAGS)
-#    set(EXTRA_CXX_FLAGS "/Zc:__cplusplus")
-#endif()
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEFAULT_CXX_FLAGS} ${EXTRA_CXX_FLAGS}")
-
 # Determine executable name
 set(exe pimc.e)
 if(CMAKE_BUILD_TYPE MATCHES Debug)
@@ -150,6 +145,14 @@ if(NOT CMAKE_BUILD_TYPE)
        CACHE STRING "Choose the type of build : None Debug Release PIGS PIGSDebug."
        FORCE)
 endif()
+
+# /Zc:__cplusplus is required to make __cplusplus accurate
+# /Zc:__cplusplus is available starting with Visual Studio 2017 version 15.7
+# (according to https://docs.microsoft.com/en-us/cpp/build/reference/zc-cplusplus)
+# That version is equivalent to _MSC_VER==1914
+# (according to https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2019)
+# CMake's ${MSVC_VERSION} is equivalent to _MSC_VER
+# (according to https://cmake.org/cmake/help/latest/variable/MSVC_VERSION.html#variable:MSVC_VERSION)
 
 if ((MSVC) AND (MSVC_VERSION GREATER_EQUAL 1914))
 	target_compile_options(${exe} PUBLIC "/Zc:__cplusplus")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,11 @@ if (NOT DEFAULT_CXX_FLAGS)
     set(DEFAULT_CXX_FLAGS "-Wall -fno-math-errno -O3")
     #set(DEFAULT_CXX_FLAGS "-march=native -Wall -fno-math-errno -O3")
 endif()
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEFAULT_CXX_FLAGS}")
+
+if (NOT EXTRA_CXX_FLAGS)
+    set(EXTRA_CXX_FLAGS "/Zc:__cplusplus")
+endif()
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEFAULT_CXX_FLAGS} ${EXTRA_CXX_FLAGS}")
 
 # Determine executable name
 set(exe pimc.e)
@@ -159,10 +163,19 @@ endif()
 include_directories( ${Boost_INCLUDE_DIRS} )
 include_directories( ${Blitz_INCLUDE_DIRS} )
 
+set(use_msvc_libs OFF)
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    if ("${CMAKE_CXX_SIMULATE_ID}" STREQUAL "MSVC")
+        set(use_msvc_libs ON)
+    endif ()
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    set(use_msvc_libs ON)
+endif ()
+
 # Link libraries
-target_link_libraries (${exe} ${Boost_LIBRARIES} )
+target_link_libraries (${exe} ${Boost_LIBRARIES} $<$<BOOL:${use_msvc_libs}>:bcrypt>)
 if((CMAKE_BUILD_TYPE MATCHES Debug) OR (CMAKE_BUILD_TYPE MATCHES PIGSDebug))
-    target_link_libraries (${exe} ${Blitz_LIBRARIES} )
+    target_link_libraries (${exe} ${Blitz_LIBRARIES})
 endif()
 
 # Link filesystem library -lstdc++fs for old compilers

--- a/include/MersenneTwister.h
+++ b/include/MersenneTwister.h
@@ -64,6 +64,8 @@
 #ifndef MERSENNETWISTER_H
 #define MERSENNETWISTER_H
 
+#define _USE_MATH_DEFINES
+
 // Not thread safe (unless auto-initialization is avoided and each thread has
 // its own MTRand object)
 

--- a/include/common.h
+++ b/include/common.h
@@ -12,10 +12,13 @@
 #ifndef COMMON_H 
 #define COMMON_H
 
+#define _USE_MATH_DEFINES
+
 #include <iomanip>
 #include <iostream>
 #include <string>
 #include <cmath>
+
 #include <cassert>
 #include <vector>
 #include <set>

--- a/include/potential.h
+++ b/include/potential.h
@@ -856,7 +856,7 @@ class SzalewiczPotential : public PotentialBase, public TabulatedPotential {
         double eta = 4.09423805117871;
         double Pn[3] = {-25.4701669416621, 269.244425630616, -56.3879970402079};
         double Qn[2] = {38.7957487310071, -2.76577136772754};
-        long int factorials[17] = {     1,
+        long long factorials[17] = {    1,
                                         1,
                                         2,
                                         6,

--- a/src/communicator.cpp
+++ b/src/communicator.cpp
@@ -7,16 +7,12 @@
 
 #include "communicator.h"
 
-/* Filesystem is tricky as it is not yet widely supported.  We try to address
- * that here. */
-#if defined(__clang__) || (defined(__GNUC__) && (__GNUC__ > 8))
-    #include <filesystem>
-    namespace fs = std::filesystem;
+#if __cplusplus < 201703L
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
 #else
-#if defined(__GNUC__) && (__GNUC__ > 6)
-        #include <experimental/filesystem>
-        namespace fs = std::experimental::filesystem;
-#endif
+#include <filesystem>
+namespace fs = std::filesystem;
 #endif
 
 // ---------------------------------------------------------------------------

--- a/src/communicator.cpp
+++ b/src/communicator.cpp
@@ -8,11 +8,11 @@
 #include "communicator.h"
 
 #if __cplusplus < 201703L
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
+    #include <experimental/filesystem>
+    namespace fs = std::experimental::filesystem;
 #else
-#include <filesystem>
-namespace fs = std::filesystem;
+    #include <filesystem>
+    namespace fs = std::filesystem;
 #endif
 
 // ---------------------------------------------------------------------------

--- a/src/pdrive.cpp
+++ b/src/pdrive.cpp
@@ -34,8 +34,6 @@ int main (int argc, char *argv[]) {
     time_t current_time; //current time
     bool wallClockReached = false;
 
-    uint32 seed = 139853;   // The seed for the random number generator
-
     Setup setup;
 
     /* Attempt to parse the command line options */
@@ -53,6 +51,8 @@ int main (int argc, char *argv[]) {
     /* Parse the setup options and possibly exit */
     if (setup.parseOptions())
         return 1;
+
+    uint32 seed = setup.params["seed"].as<uint32>();  // The seed for the random number generator (by default: 139853)
 
     /* The global random number generator, we add the process number to the seed (for
      * use in parallel simulations.*/

--- a/src/potential.cpp
+++ b/src/potential.cpp
@@ -3881,15 +3881,16 @@ GrapheneLUT3DPotentialGenerate::get_g_magnitudes(
             k += 1;
         }
     }
-    int sort_indeces[size_of_arrays];
+    
+    std::vector<int> sort_indeces(size_of_arrays, 0);
     for (int i = 0; i < size_of_arrays; i++) {
         sort_indeces[i] = i;
     }
 
     //std::sort( sort_indeces, sort_indeces + size_of_arrays,
     //        [] (int i, int j) {return g_magnitude_array(i) < g_magnitude_array(j);});
-    std::stable_sort( sort_indeces, sort_indeces + size_of_arrays,
-            [&g_magnitude_array] (int i, int j) {return g_magnitude_array(i) < g_magnitude_array(j);});
+    std::stable_sort(sort_indeces.begin(), sort_indeces.end(),
+        [&g_magnitude_array](int i, int j) {return g_magnitude_array(i) < g_magnitude_array(j); });
     // using std::stable_sort instead of std::sort
     // to avoid unnecessary index re-orderings
     // when g_magnitude_array contains elements of equal values

--- a/src/setup.cpp
+++ b/src/setup.cpp
@@ -337,6 +337,8 @@ void Setup::initParameters() {
     params.add<string>("rng,G",str(format("random number generator type:\n%s") % randomGeneratorNames).c_str(),oClass,"pimc_mt19937");
     params.add<string>("param_file","a valid path to the parameters input xml file.",oClass);
 
+    params.add<uint32>("seed", "Seed for the random number generator.",oClass,139853);
+
     /* Initialize the cell options */
     oClass = "cell";
     params.add<string>("geometry,b","simulation cell type [prism,cylinder]",oClass,"prism");


### PR DESCRIPTION
This pull request addresses several issues encountered when opening the project in Visual Studio. The proposed changes aim to resolve the following problems:

- `M_PI : undeclared identifier` errors (C2065)
- `Conversion from '__int64' to 'long' requires a narrowing conversion` errors (C2397)
- `filesystem` library import problems
- `array type 'int [size_of_arrays]' is not assignable` problem
- `bcrypt` linking problems

Additionally, an option to modify the seed of the random number generator by using `--seed` has been added.

Jacob.