### PR TITLE
Fix nonlocal action

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ else()
     file(DOWNLOAD
       "https://raw.githubusercontent.com/kokkos/mdspan/single-header/mdspan.hpp"
       "${REFERENCE_MDSPAN_BINARY}"
-      EXPECTED_MD5 "72604e49ef586d353c51257eb30ff027"  # optional hash check
+      #EXPECTED_MD5 "72604e49ef586d353c51257eb30ff027"
       STATUS DOWNLOAD_STATUS
     )
 

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1535,6 +1535,12 @@ double NonLocalAction::potentialAction (const beadLocator &bead1) {
     /* Evaluate the external potential */
     double totVext = externalPtr->V(path(bead1))+externalPtr->V(path(nextBead1));
 
+    /* Check if neighboring beads vector needs to grow */
+    // Note: commented out code showing intent.
+    //if (NNbead.size() < path.get_beads_extents()[1]) {
+        NNbead.resize(path.get_beads_extents()[1], false);
+    //}
+
     /* Get the interaction list */
     lookup.updateInteractionList(path,bead1);
     for (int n = 0; n < lookup.numBeads; n++) {


### PR DESCRIPTION
Fixes non-local action for GCE simulations.

Adds 2.5% performance penalty in the case I tested:
```
time ./pimc.e -T 0.5 -N 10 -t 0.01 -M 16 -C 1.0 --action pair_product -I hard_rod -X free --scattering_length 0.1 -E 100 -S 5 -L 100 -u 2
```

The actual performance penalty is probably negligible for long running jobs. This example had to resize the array multiple times.

This PR also removes the hash check for the MDSpan reference implementation.