### PR TITLE
Fixed bug causing empty pair correlations for non local action

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1618,7 +1618,7 @@ std::array<double,2> NonLocalAction::U(int slice) {
     int numParticles = path.numBeadsAtSlice(slice);
 
     /* Initialize the separation histogram */
-    sepHist.fill(0);
+    //sepHist.fill(0);
 
     /* Calculate the total potential, including external and interaction
      * effects*/


### PR DESCRIPTION
Commented out the initialization of the separation histogram.