### PR TITLE
Add --xyz option for reading initial particle positions from XYZ file

### DIFF
--- a/include/xyz_io.h
+++ b/include/xyz_io.h
@@ -1,0 +1,40 @@
+/**
+ * @file xyz_io.h
+ * @author Timothy R. Prisk
+ * @date 2026-06-05
+ *
+ * @brief Read initial particle positions from a plain XYZ file.
+ *
+ * This header declares readXYZFile(), a utility for parsing standard
+ * XYZ-format files and returning the contents as a DynamicArray of dVec
+ * suitable for handing to the Path constructor as an initial condition.
+ */
+#ifndef XYZ_IO_H
+#define XYZ_IO_H
+
+#include "common.h"     // pulls in dVec, DynamicArray<>, NDIM, and <string>
+
+class Container;
+
+/**
+ * @brief Peek the xyz file and get the atom count from the first line.
+ */
+int peekXYZAtomCount(const std::string &filename);
+
+/**
+ * @brief Read positions from a plain XYZ file and return them as a 
+ * DynamicArray of dVec.
+ *
+ * @param filename  Path to the XYZ file.
+ * @param boxPtr    Pointer to the simulation container.
+ *
+ * @return  A DynamicArray<dVec,1> of length N holding the positions in
+ *          Angstroms. Indexed 0..N-1.
+ *
+ * @throws std::runtime_error if the file cannot be opened, is malformed,
+ *         or contains coordinates outside the simulation cell.
+ */
+DynamicArray<dVec,1> readXYZFile(const std::string &filename,
+                                  const Container *boxPtr);
+
+#endif // XYZ_IO_H

--- a/src/pdrive.cpp
+++ b/src/pdrive.cpp
@@ -21,6 +21,8 @@
 
 #include "gpkernel.h"
 
+#include "xyz_io.h"
+
 /**
  * Main driver.
  * Read in all program options from the user using boost::program_options and setup the simulation
@@ -100,8 +102,20 @@ int main (int argc, char *argv[]) {
 
     /* Get the initial conditions associated with the external potential */
     /* Must use the copy constructor as we return a copy */
-    DynamicArray<dVec,1> initialPos = 
-        externalPotentialPtr->initialConfig(boxPtr,random,constants()->initialNumParticles());
+    //DynamicArray<dVec,1> initialPos = 
+    //    externalPotentialPtr->initialConfig(boxPtr,random,constants()->initialNumParticles());
+
+    DynamicArray<dVec,1> initialPos;
+    const std::string xyzFile = setup.params["xyz"].as<std::string>();
+    if (!xyzFile.empty()) 
+    {
+        initialPos = readXYZFile(xyzFile, boxPtr);
+    } 
+    else 
+    {
+        initialPos = externalPotentialPtr->initialConfig(boxPtr, random,
+                         constants()->initialNumParticles());
+    }
 
     /* Perform a classical canonical pre-equilibration to obtain a suitable
      * initial state if N > 0*/

--- a/src/setup.cpp
+++ b/src/setup.cpp
@@ -16,6 +16,7 @@
 #include "action.h"
 #include "move.h"
 #include "estimator.h"
+#include "xyz_io.h"   
 
 /**************************************************************************//**
  * Create a comma separated list from a vector of std::strings
@@ -414,6 +415,12 @@ void Setup::initParameters() {
     params.add<double>("end_factor","end bead potential action multiplicatave factor",oClass,1.0);
     params.add<double>("chemical_potential,u","chemical potential [kelvin]",oClass,0.0);
     params.add<int>("number_paths","number of paths",oClass,1);
+    
+    // read .xyz file for particle positions
+    params.add<std::string>("xyz", 
+        "set particle positions w/ .xyz file",
+        oClass,
+        "");
 
     /* Initialize the algorithm options */
     oClass = "algorithm";
@@ -1123,6 +1130,17 @@ void Setup::setConstants() {
     if (params["action"].as<std::string>() == "pair_product" || 
             !params("potential_cutoff") )
         params.set<double>("potential_cutoff",params["side"].as<dVec>()[NDIM-1]);
+
+
+    /* If the user has supplied an XYZ file via --xyz, the atom count from
+     * the file overrides the value of --number_particles. We do this here,
+     * before initConstants() reads from params, so that the entire
+     * downstream code sees a single, consistent value of N. */
+    if (!params["xyz"].as<std::string>().empty()) 
+    {
+        const int nFromFile = peekXYZAtomCount(params["xyz"].as<std::string>());
+        params.set<int>("number_particles", nFromFile);
+    }
 
     /* Set the required constants */
     constants()->initConstants(params());

--- a/src/xyz_io.cpp
+++ b/src/xyz_io.cpp
@@ -1,0 +1,156 @@
+/**
+ * @file xyz_io.cpp
+ * @author Timothy R. Prisk
+ * @date 2026-06-05
+ *
+ * @brief Implementation of readXYZFile().
+ */
+#include "xyz_io.h"
+#include "container.h"     // Needed to access boxPtr->side[d]
+
+#include <fstream>         // std::ifstream for reading the file
+#include <sstream>         // std::istringstream for per-line parsing
+#include <stdexcept>       // std::runtime_error for signaling failures
+#include <string>          // std::string for filename and line buffers
+
+
+// Peek into the XYZ file and get the atom count from the first line.
+int peekXYZAtomCount(const std::string &filename)
+{
+    std::ifstream fin(filename);
+    if (!fin) 
+    {
+        std::ostringstream msg;
+        msg << "peekXYZAtomCount: cannot open '" << filename << "'.";
+        throw std::runtime_error(msg.str());
+    }
+
+    std::string line;
+    if (!std::getline(fin, line))
+        throw std::runtime_error(
+            "peekXYZAtomCount: empty file (no atom count).");
+
+    int nAtoms = 0;
+    std::istringstream iss(line);
+    if (!(iss >> nAtoms) || nAtoms <= 0) 
+    {
+        std::ostringstream msg;
+        msg << "peekXYZAtomCount: first line of '" << filename
+            << "' must be a positive integer atom count; got: '"
+            << line << "'.";
+        throw std::runtime_error(msg.str());
+    }
+
+    return nAtoms;
+}
+
+
+// Tolerence check. Is this atom inside the simulation box?
+static constexpr double XYZ_BOUNDS_TOL = 1.0e-6;
+
+// Read the XYZ file and return the positions as a DynamicArray<dVec,1>.
+DynamicArray<dVec,1> readXYZFile(const std::string &filename,
+                                  const Container *boxPtr)
+{
+    // Open the file.
+    std::ifstream fin(filename);
+    if (!fin) 
+    {
+        std::ostringstream msg;
+        msg << "readXYZFile: cannot open '" << filename << "'.";
+        throw std::runtime_error(msg.str());
+    }
+
+    // Get the number of atoms from the first line.
+    int nAtoms = 0;
+    {
+        std::string line;
+        if (!std::getline(fin, line))
+            throw std::runtime_error("readXYZFile: empty file (no atom count).");
+        std::istringstream iss(line);
+        if (!(iss >> nAtoms) || nAtoms <= 0) 
+        {
+            std::ostringstream msg;
+            msg << "readXYZFile: first line of '" << filename
+                << "' must be a positive integer atom count; got: '"
+                << line << "'.";
+            throw std::runtime_error(msg.str());
+        }
+    }
+
+    // Ignore the second line (comment).
+    {
+        std::string comment;
+        if (!std::getline(fin, comment))
+            throw std::runtime_error(
+                "readXYZFile: file ended before comment line.");
+    }
+
+    // Read N atoms from the remaining lines. Each line has format:
+    //   <element> <x> <y> <z>
+    // where <element> is read into a string and thrown away, and the three
+    // coordinates are parsed as doubles in Angstroms.
+    DynamicArray<dVec,1> positions(nAtoms);
+
+    for (int i = 0; i < nAtoms; ++i) 
+    {
+        std::string line;
+        if (!std::getline(fin, line)) 
+        {
+            std::ostringstream msg;
+            msg << "readXYZFile: file '" << filename
+                << "' ended after " << i << " atoms; expected " << nAtoms << ".";
+            throw std::runtime_error(msg.str());
+        }
+
+        // Parse element + NDIM coordinates from the line.
+        std::istringstream iss(line);
+        std::string element;
+        dVec pos;
+
+        if (!(iss >> element)) 
+        {
+            std::ostringstream msg;
+            msg << "readXYZFile: could not parse element column for atom "
+                << i << " in '" << filename << "'. Line: '" << line << "'.";
+            throw std::runtime_error(msg.str());
+        }
+
+        for (int d = 0; d < NDIM; ++d) 
+        {
+            if (!(iss >> pos[d])) {
+                std::ostringstream msg;
+                msg << "readXYZFile: could not parse coordinate " << d
+                    << " for atom " << i << " in '" << filename
+                    << "'. Line: '" << line << "'.";
+                throw std::runtime_error(msg.str());
+            }
+        }
+
+        /* Bounds check: the simulation cell is centered at the origin, so
+         * each coordinate must lie in [-side[d]/2, +side[d]/2], within the
+         * XYZ_BOUNDS_TOL tolerance. The user is responsible for ensuring
+         * the box (set via -L or computed from -n) is large enough to
+         * contain all atoms. */
+        for (int d = 0; d < NDIM; ++d) 
+        {
+            const double half = 0.5 * boxPtr->side[d];
+            if (pos[d] < -half - XYZ_BOUNDS_TOL ||
+                pos[d] >  half + XYZ_BOUNDS_TOL) 
+                {
+                std::ostringstream msg;
+                msg << "readXYZFile: atom " << i
+                    << " is outside the simulation cell in dimension " << d
+                    << ". Coordinate = " << pos[d]
+                    << " A, box half-extent = " << half << " A. "
+                    << "Check that -L (or -n and -N) define a cell large enough "
+                    << "to contain all atoms in '" << filename << "'.";
+                throw std::runtime_error(msg.str());
+            }
+        }
+
+        positions(i) = pos;
+    }
+
+    return positions;
+}


### PR DESCRIPTION
## Summary

Adds a `--xyz <path>` command-line option that initializes particle positions from an XYZ file rather than from the default external-potential `initialConfig()` lattice.

## Behavior

The atom count from the file overrides `-N` from the command line.  The first line of the .xyz file is taken as N.  The second line is skipped.  The remainder of the file takes atomic coordinates, ignoring the atom labels.

## Files changed

- `include/xyz_io.h`  — declares `peekXYZAtomCount()` and `readXYZFile()`.
- `src/xyz_io.cpp` — implementations of both.
- `src/setup.cpp`  — registers the `--xyz` option and overrides `number_particles` from the file count.
- `src/pdrive.cpp`  — branches on `--xyz` to load positions from file instead of from `initialConfig()`.