### PR TITLE
Add FinalStateEffectsEstimator

### DIFF
--- a/include/estimator.h
+++ b/include/estimator.h
@@ -762,6 +762,33 @@ class PairCorrelationEstimator: public EstimatorBase {
         double dR;                      // The discretization
 };
 
+// ========================================================================
+// Final State Effects Estimator Class
+// ========================================================================
+/**
+ * Compute final state effects in the additive approach.  Leading corrections
+ * are due to <\nabla^2 V> and <F^2>, where F = -\nabla V is the force. 
+ *
+ * @see G.J. Sears, Phys. Rev. B 30, 44 (1984).
+ *
+ */
+class FinalStateEffectsEstimator : public EstimatorBase {
+
+    public:
+        FinalStateEffectsEstimator(const Path &, ActionBase *,
+                const MTRand &, double, int _frequency=1,
+                std::string _label="fse");
+        ~FinalStateEffectsEstimator();
+
+        static const std::string name;
+        std::string getName() const { return name; }
+
+    private:
+        void accumulate();
+};
+
+
+
 // ========================================================================  
 // Static Structure Factor Estimator Class
 // ========================================================================  

--- a/src/estimator.cpp
+++ b/src/estimator.cpp
@@ -11,6 +11,9 @@
 #include "potential.h"
 #include "communicator.h"
 #include "factory.h"
+#include <complex>
+#include <queue>
+#include <array>
 #include <vector>
 #ifdef USE_HIP
     #include "estimator_gpu.hip.h"
@@ -57,6 +60,7 @@ REGISTER_ESTIMATOR("pair correlation function",PairCorrelationEstimator);
 REGISTER_ESTIMATOR("static structure factor",StaticStructureFactorEstimator);
 REGISTER_ESTIMATOR("intermediate scattering function",IntermediateScatteringFunctionEstimator);
 REGISTER_ESTIMATOR("radial density",RadialDensityEstimator);
+REGISTER_ESTIMATOR("final state effects", FinalStateEffectsEstimator);
 #if NDIM > 1
 REGISTER_ESTIMATOR("radial area rhos/rho",RadialAreaSuperfluidDensityEstimator);
 REGISTER_ESTIMATOR("planar area rhos/rho",PlaneAreaSuperfluidDensityEstimator);
@@ -3239,6 +3243,93 @@ void PairCorrelationEstimator::accumulate() {
     else
         estimator += 0.0;
 }
+
+
+// ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// FINAL STATE EFFECTS ESTIMATOR CLASS ---------------------------------------
+// ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+
+/*************************************************************************//**
+ *  Constructor.
+******************************************************************************/
+FinalStateEffectsEstimator::FinalStateEffectsEstimator(
+        const Path &_path, ActionBase *_actionPtr,
+        const MTRand &_random, double _maxR,
+        int _frequency, std::string _label) :
+    EstimatorBase(_path, _actionPtr, _random, _maxR,
+                  _frequency, _label)
+{
+    initialize(2);
+
+    header = str(format("#%15s%16s") % "F2" % "lapV");
+}
+
+FinalStateEffectsEstimator::~FinalStateEffectsEstimator() { }
+
+
+/*************************************************************************//**
+ *  Accumulate one measurement of <F^2> and <nabla^2 V>.
+ *
+ *  For each imaginary-time slice s and each particle i, form the
+ *  net force vector and the 3D Laplacian as explicit pair sums
+ *
+ *      F_i = sum_{j != i} gradV(r_ij)
+ *      L_i = sum_{j != i} [ d^2V/dr^2(r_ij) + 2/r_ij dV/dr(r_ij) ]
+ *
+ *  where gradV returns the gradient vector v'(r) * rhat and
+ *  grad2V returns the radial second derivative v''(r).  The
+ *  geometric piece 2 v'(r)/r is reconstructed using the identity
+ *
+ *      gradV . rij / r^2  =  v'(r) rhat . rij / r^2  =  v'(r)/r.
+ *
+ *  Complexity per measurement: O(N^2 M). 
+******************************************************************************/
+void FinalStateEffectsEstimator::accumulate()
+{
+    const int M = path.numTimeSlices;
+    const int N = path.getTrueNumParticles();
+    PotentialBase *vptr = actionPtr->interactionPtr;
+
+    double F2_sum  = 0.0;
+    double lap_sum = 0.0;
+
+    for (int s = 0; s < M; ++s) {
+        for (int i = 0; i < N; ++i) {
+            beadLocator bi = {s, i};
+            dVec   Fi{};       // net force on particle i (vector)
+            double Li = 0.0;   // 3D Laplacian at particle i
+
+            for (int j = 0; j < N; ++j) {
+                if (j == i) continue;
+                beadLocator bj = {s, j};
+                dVec rij = path.getSeparation(bi, bj);
+                dVec gV  = vptr->gradV(rij);    // = v'(r) * rhat
+
+                /* Full Laplacian = d^2V/dr^2 + 2 v'(r)/r.  The
+                 * radial second derivative is what grad2V() returns;
+                 * the geometric piece 2 v'(r)/r is recovered from
+                 * (gV . rij) / r^2 = v'(r) / r. */
+                double r2 = dot(rij, rij);
+                double lap_ij = vptr->grad2V(rij)
+                              + 2.0 * dot(gV, rij) / r2;
+
+                Fi += gV;
+                Li += lap_ij;
+            }
+
+            F2_sum  += dot(Fi, Fi);
+            lap_sum += Li;
+        }
+    }
+
+    const double denom = double(N) * double(M);
+    estimator(0) += F2_sum  / denom;
+    estimator(1) += lap_sum / denom;
+}
+
+
 
 // ---------------------------------------------------------------------------
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `FinalStateEffectsEstimator`, an estimator that returns two scalars per measurement: <F^2>, the mean-square force on each particle, and ⟨∇²V⟩, the mean Laplacian of the inter-particle potential.  In neutron Compton scattering, these observables determine final state effects within the additive approach.

## Implementation

At each imaginary time slice, the estimator determines the mean-squared net force <F^2> and the average curvature of the potential <\nabla^2 V>.

```
F_i = sum_{j != i} gradV(r_ij)
L_i = sum_{j != i} [ d²V/dr²(r_ij) + 2/r_ij · dV/dr(r_ij) ]
```

## Files changed

- `include/estimator.h` — `FinalStateEffectsEstimator` class declaration.
- `src/estimator.cpp`  — implementation, three forwarding `#include`s (`<complex>`, `<queue>`, `<array>`), and the `REGISTER_ESTIMATOR("final state effects", FinalStateEffectsEstimator)` line.