### PR TITLE
Fix estimator header merge conflict; add Patkowski and XeLJ potentials

### DIFF
--- a/include/estimator.h
+++ b/include/estimator.h
@@ -97,8 +97,8 @@ class EstimatorBase {
 
         std::map<std::string,int> estIndex;       ///< Map estimator labels to indices.
 
-        DynamicArray<double,1> estimator;      ///< The estimator array
-        DynamicArray<double,1> norm;           ///< The normalization factor for each estimator
+    DynamicArray<double,1> estimator;      ///< The estimator array
+    DynamicArray<double,1> norm;           ///< The normalization factor for each estimator
 
         int numEst;                     ///< The number of individual quantities measured
         int frequency;                  ///< The frequency at which we accumulate
@@ -762,27 +762,37 @@ class PairCorrelationEstimator: public EstimatorBase {
         double dR;                      // The discretization
 };
 
-// ========================================================================
-// Final State Effects Estimator Class
-// ========================================================================
+// ============================================================================
+//  Bond-Orientational-Order Estimator 
+// ----------------------------------------------------------------------------
 /**
- * Compute final state effects in the additive approach.  Leading corrections
- * are due to <\nabla^2 V> and <F^2>, where F = -\nabla V is the force. 
+ * Computes Steinhardt q_l (l = 4, 6) and the Lechner-Dellago averaged
+ * qbar_l, both on the slice-by-slice configuration and on the imaginary-
+ * time-averaged centroid positions.  Eight scalars are written per bin:
  *
- * @see G.J. Sears, Phys. Rev. B 30, 44 (1984).
+ *    q4_slice  q6_slice  qbar4_slice  qbar6_slice
+ *     q4_cent   q6_cent   qbar4_cent   qbar6_cent
  *
+ * This is a *diagonal* estimator (only samples when the worm is closed),
+ *  so EstimatorBase::baseSample() automatically gates it.
+ *
+ *
+ * @see P.J. Steinhardt, D.R. Nelson, M. Ronchetti, Phys. Rev. B 28, 784
+ *      (1983).  Original q_l definition.
+ * @see W. Lechner, C. Dellago, J. Chem. Phys. 129, 114707 (2008).
+ *      Averaged qbar_l variant.
  */
-class FinalStateEffectsEstimator : public EstimatorBase {
+class BondOrientationalOrderEstimator : public EstimatorBase {
 
     public:
-        FinalStateEffectsEstimator(const Path &, ActionBase *,
+        BondOrientationalOrderEstimator(const Path &, ActionBase *,
                 const MTRand &, double, int _frequency=1,
-                std::string _label="fse");
-        ~FinalStateEffectsEstimator();
+                std::string _label="bondord");
+        ~BondOrientationalOrderEstimator();
 
         static const std::string name;
-        std::string getname() const {return name;}
-  
+        std::string getName() const { return name; }
+
     private:
         void accumulate();              // Accumulate the 8 quantities
 
@@ -814,42 +824,32 @@ class FinalStateEffectsEstimator : public EstimatorBase {
         // Centroid of the ring polymer starting at slice 0.
         dVec computeCentroid(int p);
 };
-  
-  
-// ============================================================================
-//  Bond-Orientational-Order Estimator 
-// ----------------------------------------------------------------------------
+
+// ========================================================================
+// Final State Effects Estimator Class
+// ========================================================================
 /**
- * Computes Steinhardt q_l (l = 4, 6) and the Lechner-Dellago averaged
- * qbar_l, both on the slice-by-slice configuration and on the imaginary-
- * time-averaged centroid positions.  Eight scalars are written per bin:
+ * Compute final state effects in the additive approach.  Leading corrections
+ * are due to <\nabla^2 V> and <F^2>, where F = -\nabla V is the force. 
  *
- *    q4_slice  q6_slice  qbar4_slice  qbar6_slice
- *     q4_cent   q6_cent   qbar4_cent   qbar6_cent
+ * @see G.J. Sears, Phys. Rev. B 30, 44 (1984).
  *
- * This is a *diagonal* estimator (only samples when the worm is closed),
- *  so EstimatorBase::baseSample() automatically gates it.
- *
- *
- * @see P.J. Steinhardt, D.R. Nelson, M. Ronchetti, Phys. Rev. B 28, 784
- *      (1983).  Original q_l definition.
- * @see W. Lechner, C. Dellago, J. Chem. Phys. 129, 114707 (2008).
- *      Averaged qbar_l variant.
  */
-// class BondOrientationalOrderEstimator : public EstimatorBase {
+class FinalStateEffectsEstimator : public EstimatorBase {
 
-//     public:
-//         BondOrientationalOrderEstimator(const Path &, ActionBase *,
-//                 const MTRand &, double, int _frequency=1,
-//                 std::string _label="bondord");
-//         ~BondOrientationalOrderEstimator();
+    public:
+        FinalStateEffectsEstimator(const Path &, ActionBase *,
+                const MTRand &, double, int _frequency=1,
+                std::string _label="fse");
+        ~FinalStateEffectsEstimator();
 
-//         static const std::string name;
-//         std::string getName() const { return name; }
+        static const std::string name;
+        std::string getName() const { return name; }
 
-//     private:
-//         void accumulate();
-// };
+    private:
+        void accumulate();
+};
+
 
 
 // ========================================================================  

--- a/include/potential.h
+++ b/include/potential.h
@@ -1213,6 +1213,101 @@ class H2LJ : public PotentialBase, public TabulatedPotential<H2LJ>
      return g2V;
  }
 
+// ========================================================================
+// PatkowskiPotential Class
+// ========================================================================
+//
+//  Spherically-averaged (isotropic) H2-H2 pair potential of
+//  K. Patkowski, W. Cencek, P. Jankowski, K. Szalewicz, J. B. Mehl,
+//  G. Garberoglio, A. H. Harvey,  J. Chem. Phys. 129, 094304 (2008).
+//
+//  The supplementary material contains Fortran source code for the isotropic 
+// potential, which is used here to implement the PatkowskiPotential class. 
+
+class PatkowskiPotential : public PotentialBase,
+                           public TabulatedPotential<PatkowskiPotential> {
+    public:
+        PatkowskiPotential (const Container *);
+        ~PatkowskiPotential ();
+
+        inline __attribute__((always_inline)) double V(const dVec &);
+        inline __attribute__((always_inline)) dVec gradV(const dVec &);
+
+        // Radial 2nd derivative d^2V/dr^2 (NOT the 3D Laplacian), K/A^2.
+        inline __attribute__((always_inline)) double grad2V(const dVec &);
+
+        inline __attribute__((always_inline)) double valueV     (const double);
+        inline __attribute__((always_inline)) double valuedVdr  (const double);
+        inline __attribute__((always_inline)) double valued2Vdr2(const double);
+
+    private:
+        // All parameters preserved as they appear in the EPAPS
+        // Fortran block-data (isoH2H2.f / fit_param.txt).
+        double cex[2];      // short-range exp prefactor params
+        double csp[4];      // short-range polynomial coeffs (K, K/bohr, ...)
+        double cdata[3];    // long-range C_n^000 for n=6,8,10  (a.u., negative)
+
+        // Inner hard-wall plateau r < 0.75 A
+        double r_inner_A;     // Angstroms
+        double V_inner_K;     // Kelvin
+
+        // Unit conversions.
+        double BohrPerAngstrom;     // R[bohr] = r[A] * BohrPerAngstrom
+        double xK2au;               // 1 K = xK2au atomic units
+
+        // Tang-Toennies damping function.
+        double TT_f (const int n, const double x) const 
+        {
+            double term = 1.0, sum = 1.0;
+            for (int k = 1; k <= n; ++k) 
+            {
+                term *= x / static_cast<double>(k);
+                sum  += term;
+            }
+            return 1.0 - exp(-x) * sum;
+        }
+
+        double TT_df(const int n, const double x) const 
+        {
+            double xn_over_nfact = 1.0;
+            for (int k = 1; k <= n; ++k)
+                xn_over_nfact *= x / static_cast<double>(k);
+            return exp(-x) * xn_over_nfact;
+        }
+
+        double TT_d2f(const int n, const double x) const 
+        {
+            if (x == 0.0) return 0.0;
+            return TT_df(n, x) * (static_cast<double>(n) - x) / x;
+        }
+};
+
+
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+// INLINE FUNCTION DEFINITIONS
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+inline __attribute__((always_inline))
+double PatkowskiPotential::V(const dVec &r)
+{
+    return direct(lookupV, extV, sqrt(dot(r,r)));
+}
+
+inline __attribute__((always_inline))
+dVec PatkowskiPotential::gradV(const dVec &r)
+{
+    double rnorm = sqrt(dot(r,r));
+    dVec gV;
+    gV = (direct(lookupdVdr, extdVdr, rnorm) / rnorm) * r;
+    return gV;
+}
+
+inline __attribute__((always_inline))
+double PatkowskiPotential::grad2V(const dVec &r)
+{
+    double rnorm = sqrt(dot(r,r));
+    return direct(lookupd2Vdr2, extd2Vdr2, rnorm);
+}
 
 // ========================================================================  
 // Szalewicz Potential Class

--- a/src/estimator.cpp
+++ b/src/estimator.cpp
@@ -60,8 +60,8 @@ REGISTER_ESTIMATOR("pair correlation function",PairCorrelationEstimator);
 REGISTER_ESTIMATOR("static structure factor",StaticStructureFactorEstimator);
 REGISTER_ESTIMATOR("intermediate scattering function",IntermediateScatteringFunctionEstimator);
 REGISTER_ESTIMATOR("radial density",RadialDensityEstimator);
+REGISTER_ESTIMATOR("bond orientational order", BondOrientationalOrderEstimator);
 REGISTER_ESTIMATOR("final state effects", FinalStateEffectsEstimator);
-// REGISTER_ESTIMATOR("bond orientational order", BondOrientationalOrderEstimator);
 #if NDIM > 1
 REGISTER_ESTIMATOR("radial area rhos/rho",RadialAreaSuperfluidDensityEstimator);
 REGISTER_ESTIMATOR("planar area rhos/rho",PlaneAreaSuperfluidDensityEstimator);
@@ -3248,6 +3248,322 @@ void PairCorrelationEstimator::accumulate() {
 
 // ---------------------------------------------------------------------------
 // ---------------------------------------------------------------------------
+// BOND-ORIENTATIONAL-ORDER ESTIMATOR CLASS ----------------------------------
+// ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+
+/*****************************************************************************
+ *  Constructor.
+******************************************************************************/
+BondOrientationalOrderEstimator::BondOrientationalOrderEstimator(
+        const Path &_path, ActionBase *_actionPtr,
+        const MTRand &_random, double _maxR,
+        int _frequency, std::string _label) :
+    EstimatorBase(_path,_actionPtr,_random,_maxR,_frequency,_label)
+{
+    initialize(8);
+
+    header = str(format("#%15s%16s%16s%16s%16s%16s%16s%16s")
+            % "q4_slice"  % "q6_slice"
+            % "qbar4_slice" % "qbar6_slice"
+            % "q4_cent"   % "q6_cent"
+            % "qbar4_cent"  % "qbar6_cent");
+}
+
+BondOrientationalOrderEstimator::~BondOrientationalOrderEstimator() { }
+
+
+/*************************************************************************//**
+ * Spherical harmonics helpers. 
+ *
+ *  Phase convention matches Arfken and Weber, and also scipy.
+******************************************************************************/
+void BondOrientationalOrderEstimator::Ylm_l4(
+        const dVec &rhat, std::complex<double> Ylm[9])
+{
+    const double x = rhat[0], y = rhat[1], z = rhat[2];
+    const double z2 = z*z, z3 = z2*z, z4 = z2*z2;
+    const std::complex<double> w(x, y);            // x + i y
+    const std::complex<double> w2 = w*w, w3 = w2*w, w4 = w2*w2;
+    const double invSqrtPi = 1.0 / std::sqrt(M_PI);
+
+    /* m = 0 */
+    Ylm[4] = (3.0/16.0) * invSqrtPi
+                    * (35.0*z4 - 30.0*z2 + 3.0);
+    /* m = +1 */
+    Ylm[5] = -(3.0/8.0) * std::sqrt(5.0/M_PI)
+                    * (7.0*z3 - 3.0*z) * w;
+    /* m = +2 */
+    Ylm[6] = (3.0/8.0) * std::sqrt(5.0/(2.0*M_PI))
+                    * (7.0*z2 - 1.0) * w2;
+    /* m = +3 */
+    Ylm[7] = -(3.0/8.0) * std::sqrt(35.0/M_PI) * z * w3;
+    /* m = +4 */
+    Ylm[8] = (3.0/16.0) * std::sqrt(35.0/(2.0*M_PI)) * w4;
+
+    /* m < 0 via Y_l^{-m} = (-1)^m conj(Y_l^{+m}) */
+    Ylm[3] = -std::conj(Ylm[5]);   // m = -1
+    Ylm[2] =  std::conj(Ylm[6]);   // m = -2
+    Ylm[1] = -std::conj(Ylm[7]);   // m = -3
+    Ylm[0] =  std::conj(Ylm[8]);   // m = -4
+}
+
+void BondOrientationalOrderEstimator::Ylm_l6(
+        const dVec &rhat, std::complex<double> Ylm[13])
+{
+    const double x = rhat[0], y = rhat[1], z = rhat[2];
+    const double z2 = z*z, z3 = z2*z, z4 = z2*z2;
+    const double z5 = z4*z, z6 = z3*z3;
+    const std::complex<double> w(x, y);
+    const std::complex<double> w2 = w*w, w3 = w2*w;
+    const std::complex<double> w4 = w2*w2, w5 = w4*w, w6 = w3*w3;
+
+    /* m = 0 */
+    Ylm[6]  = (1.0/32.0) * std::sqrt(13.0/M_PI)
+                    * (231.0*z6 - 315.0*z4 + 105.0*z2 - 5.0);
+    /* m = +1 */
+    Ylm[7]  = -(1.0/16.0) * std::sqrt(273.0/(2.0*M_PI))
+                    * (33.0*z5 - 30.0*z3 + 5.0*z) * w;
+    /* m = +2 */
+    Ylm[8]  = (1.0/64.0) * std::sqrt(1365.0/M_PI)
+                    * (33.0*z4 - 18.0*z2 + 1.0) * w2;
+    /* m = +3 */
+    Ylm[9]  = -(1.0/32.0) * std::sqrt(1365.0/M_PI)
+                    * z * (11.0*z2 - 3.0) * w3;
+    /* m = +4 */
+    Ylm[10] = (21.0/32.0) * std::sqrt(13.0/(14.0*M_PI))
+                    * (11.0*z2 - 1.0) * w4;
+    /* m = +5 */
+    Ylm[11] = -(3.0/32.0) * std::sqrt(1001.0/M_PI) * z * w5;
+    /* m = +6 */
+    Ylm[12] = (1.0/64.0) * std::sqrt(3003.0/M_PI) * w6;
+
+    /* m < 0 via Y_l^{-m} = (-1)^m conj(Y_l^{+m}); for l = 6, m = 1..6
+     * the signs alternate -, +, -, +, -, +. */
+    Ylm[5] = -std::conj(Ylm[7]);    // m = -1
+    Ylm[4] =  std::conj(Ylm[8]);    // m = -2
+    Ylm[3] = -std::conj(Ylm[9]);    // m = -3
+    Ylm[2] =  std::conj(Ylm[10]);   // m = -4
+    Ylm[1] = -std::conj(Ylm[11]);   // m = -5
+    Ylm[0] =  std::conj(Ylm[12]);   // m = -6
+}
+
+
+/*************************************************************************//**
+ *  Find the kNN nearest neighbors of `positions[p_self]` and write their 
+ *  unit-vector directions to `rhat`.
+******************************************************************************/
+void BondOrientationalOrderEstimator::findKNearestNeighbors(
+        int p_self,
+        const std::vector<dVec> &positions,
+        std::vector<int> &nbrs,
+        std::vector<dVec> &rhat)
+{
+    const int N = positions.size();
+    const dVec &r_i = positions[p_self];
+
+    // Max-heap of (d2, j) keeping the kNN smallest d2 values.
+    std::priority_queue<std::pair<double,int>> heap;
+
+    for (int j = 0; j < N; ++j) {
+        if (j == p_self) continue;
+        // Minimum-image displacement.  The expression
+        //     s -= L * floor(s/L + 0.5)
+        // subtracts the integer multiple of L closest to s, which is the
+        // branchless equivalent of "if s > L/2 subtract L; if s < -L/2 add L".
+        dVec dr;
+        for (int d = 0; d < NDIM; ++d) {
+            double s = positions[j][d] - r_i[d];
+            double L = path.boxPtr->side[d];
+            s -= L * std::floor(s / L + 0.5);
+            dr[d] = s;
+        }
+        double d2 = dot(dr, dr);
+        if ((int)heap.size() < kNN) {
+            heap.push({d2, j});
+        } else if (d2 < heap.top().first) {
+            heap.pop();
+            heap.push({d2, j});
+        }
+    }
+
+    // Drain heap and store the unit-vector directions.
+    nbrs.resize(kNN);
+    rhat.resize(kNN);
+    for (int n = kNN - 1; n >= 0; --n) {
+        double d2 = heap.top().first;
+        int j = heap.top().second;
+        heap.pop();
+        nbrs[n] = j;
+        const dVec &r_j = positions[j];
+        double inv_d = 1.0 / std::sqrt(d2);
+        for (int d = 0; d < NDIM; ++d) {
+            double s = r_j[d] - r_i[d];
+            double L = path.boxPtr->side[d];
+            s -= L * std::floor(s / L + 0.5);
+            rhat[n][d] = s * inv_d;
+        }
+    }
+}
+
+
+/*************************************************************************//**
+ *  Compute the supercell-averaged q_l and qbar_l for l = 4, 6, for one
+ *  configuration of N atomic positions (slice or centroid).
+******************************************************************************/
+void BondOrientationalOrderEstimator::computeQValues(
+        const std::vector<dVec> &positions,
+        double &q4_avg, double &q6_avg,
+        double &qbar4_avg, double &qbar6_avg)
+{
+    const int N = positions.size();
+
+    /* Storage for per-particle q_lm values (l = 4 -> 9 cmplx,
+     * l = 6 -> 13 cmplx). */
+    std::vector<std::array<std::complex<double>, 9>>  qlm4(N);
+    std::vector<std::array<std::complex<double>, 13>> qlm6(N);
+    std::vector<std::vector<int>> all_nbrs(N);
+
+    // Pass 1: for each i, find neighbors and accumulate q_lm(i).
+    std::vector<int> nbrs;
+    std::vector<dVec> rhat;
+    std::complex<double> Y4[9], Y6[13];
+    for (int i = 0; i < N; ++i) {
+        findKNearestNeighbors(i, positions, nbrs, rhat);
+        all_nbrs[i] = nbrs;
+        for (int m = 0; m < 9;  ++m) qlm4[i][m] = 0.0;
+        for (int m = 0; m < 13; ++m) qlm6[i][m] = 0.0;
+        for (int n = 0; n < kNN; ++n) {
+            Ylm_l4(rhat[n], Y4);
+            Ylm_l6(rhat[n], Y6);
+            for (int m = 0; m < 9;  ++m) qlm4[i][m] += Y4[m];
+            for (int m = 0; m < 13; ++m) qlm6[i][m] += Y6[m];
+        }
+        for (int m = 0; m < 9;  ++m) qlm4[i][m] /= (double)kNN;
+        for (int m = 0; m < 13; ++m) qlm6[i][m] /= (double)kNN;
+    }
+
+     // Pass 2: for each i, build qbar_lm(i) by averaging q_lm over
+     //            particle i and its kNN neighbors (N_b+1 = 13 terms).
+     //  Then sum the rotation-invariant magnitudes over the supercell and
+     //  divide by N to get the average q_l and qbar_l.
+    q4_avg = q6_avg = qbar4_avg = qbar6_avg = 0.0;
+    const double pf4 = 4.0*M_PI / 9.0;        // 4 pi / (2 l + 1) for l=4
+    const double pf6 = 4.0*M_PI / 13.0;       // 4 pi / (2 l + 1) for l=6
+    for (int i = 0; i < N; ++i) {
+        // qbar_lm: average q_lm over particle i AND its kNN neighbors
+        std::array<std::complex<double>, 9>  qb4{};
+        std::array<std::complex<double>, 13> qb6{};
+        for (int m = 0; m < 9;  ++m) qb4[m] = qlm4[i][m];
+        for (int m = 0; m < 13; ++m) qb6[m] = qlm6[i][m];
+        for (int n = 0; n < kNN; ++n) {
+            int j = all_nbrs[i][n];
+            for (int m = 0; m < 9;  ++m) qb4[m] += qlm4[j][m];
+            for (int m = 0; m < 13; ++m) qb6[m] += qlm6[j][m];
+        }
+        const double w = 1.0 / (double)(kNN + 1);
+        for (int m = 0; m < 9;  ++m) qb4[m] *= w;
+        for (int m = 0; m < 13; ++m) qb6[m] *= w;
+
+        // sum_m |q_lm|^2 -> rotation invariants
+        double s4 = 0, s6 = 0, sb4 = 0, sb6 = 0;
+        for (int m = 0; m < 9;  ++m) s4  += std::norm(qlm4[i][m]);
+        for (int m = 0; m < 13; ++m) s6  += std::norm(qlm6[i][m]);
+        for (int m = 0; m < 9;  ++m) sb4 += std::norm(qb4[m]);
+        for (int m = 0; m < 13; ++m) sb6 += std::norm(qb6[m]);
+
+        q4_avg    += std::sqrt(pf4 * s4 );
+        q6_avg    += std::sqrt(pf6 * s6 );
+        qbar4_avg += std::sqrt(pf4 * sb4);
+        qbar6_avg += std::sqrt(pf6 * sb6);
+    }
+    q4_avg    /= (double)N;
+    q6_avg    /= (double)N;
+    qbar4_avg /= (double)N;
+    qbar6_avg /= (double)N;
+}
+
+
+/*************************************************************************//**
+ *  Compute the centroid of the ring polymer that begins at slice 0,
+ *  particle p, by walking path.next() for numTimeSlices steps and
+ *  accumulating positions while unwrapping minimum-image jumps.
+******************************************************************************/
+dVec BondOrientationalOrderEstimator::computeCentroid(int p)
+{
+    const int M = path.numTimeSlices;
+    beadLocator bead = {0, p};
+    dVec abs_pos = path(bead);
+    dVec sum = abs_pos;
+    for (int s = 1; s < M; ++s) {
+        beadLocator bnext = path.next(bead);
+        /* getSeparation returns r(bnext) - r(bead) under min-image */
+        dVec dr = path.getSeparation(bnext, bead);
+        abs_pos += dr;
+        sum += abs_pos;
+        bead = bnext;
+    }
+    sum /= (double)M;
+    path.boxPtr->putInside(sum);   // wrap centroid back to [-L/2, L/2]
+    return sum;
+}
+
+
+/*************************************************************************//**
+ *  Accumulate one measurement of the 8 bond-orientational-order
+ *  quantities into the estimator array.
+******************************************************************************/
+void BondOrientationalOrderEstimator::accumulate()
+{
+    const int M = path.numTimeSlices;
+    const int N = path.getTrueNumParticles();
+
+    // PER-SLICE: average q_l, qbar_l over all M imaginary-time slices.
+    // For each slice s we build an N-vector of positions, compute the
+    // supercell-averaged q's, and accumulate.
+    std::vector<dVec> positions(N);
+    double q4_s = 0, q6_s = 0, qbar4_s = 0, qbar6_s = 0;
+    for (int s = 0; s < M; ++s) {
+        /* Gather positions at this slice.  In a closed-worm config
+         * the number of beads per slice equals N. */
+        for (int p = 0; p < N; ++p) {
+            beadLocator bead = {s, p};
+            positions[p] = path(bead);
+        }
+        double a4, a6, b4, b6;
+        computeQValues(positions, a4, a6, b4, b6);
+        q4_s    += a4;
+        q6_s    += a6;
+        qbar4_s += b4;
+        qbar6_s += b6;
+    }
+    q4_s    /= (double)M;
+    q6_s    /= (double)M;
+    qbar4_s /= (double)M;
+    qbar6_s /= (double)M;
+
+    // CENTROID: trace each ring polymer to get the imag-time-averaged
+    // position of each particle.
+    std::vector<dVec> centroids(N);
+    for (int p = 0; p < N; ++p)
+        centroids[p] = computeCentroid(p);
+    double q4_c, q6_c, qbar4_c, qbar6_c;
+    computeQValues(centroids, q4_c, q6_c, qbar4_c, qbar6_c);
+
+    // Push into the estimator array (8 columns).
+    estimator(0) += q4_s;
+    estimator(1) += q6_s;
+    estimator(2) += qbar4_s;
+    estimator(3) += qbar6_s;
+    estimator(4) += q4_c;
+    estimator(5) += q6_c;
+    estimator(6) += qbar4_c;
+    estimator(7) += qbar6_c;
+}
+
+
+// ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 // FINAL STATE EFFECTS ESTIMATOR CLASS ---------------------------------------
 // ---------------------------------------------------------------------------
 // ---------------------------------------------------------------------------
@@ -3330,320 +3646,6 @@ void FinalStateEffectsEstimator::accumulate()
     estimator(1) += lap_sum / denom;
 }
 
-// ---------------------------------------------------------------------------
-// ---------------------------------------------------------------------------
-// BOND-ORIENTATIONAL-ORDER ESTIMATOR CLASS ----------------------------------
-// ---------------------------------------------------------------------------
-// ---------------------------------------------------------------------------
-
-/*****************************************************************************
- *  Constructor.
-******************************************************************************/
-// BondOrientationalOrderEstimator::BondOrientationalOrderEstimator(
-//         const Path &_path, ActionBase *_actionPtr,
-//         const MTRand &_random, double _maxR,
-//         int _frequency, std::string _label) :
-//     EstimatorBase(_path,_actionPtr,_random,_maxR,_frequency,_label)
-// {
-//     initialize(8);
-
-//     header = str(format("#%15s%16s%16s%16s%16s%16s%16s%16s")
-//             % "q4_slice"  % "q6_slice"
-//             % "qbar4_slice" % "qbar6_slice"
-//             % "q4_cent"   % "q6_cent"
-//             % "qbar4_cent"  % "qbar6_cent");
-// }
-
-// BondOrientationalOrderEstimator::~BondOrientationalOrderEstimator() { }
-
-
-// /*************************************************************************//**
-//  * Spherical harmonics helpers. 
-//  *
-//  *  Phase convention matches Arfken and Weber, and also scipy.
-// ******************************************************************************/
-// void BondOrientationalOrderEstimator::Ylm_l4(
-//         const dVec &rhat, std::complex<double> Ylm[9])
-// {
-//     const double x = rhat[0], y = rhat[1], z = rhat[2];
-//     const double z2 = z*z, z3 = z2*z, z4 = z2*z2;
-//     const std::complex<double> w(x, y);            // x + i y
-//     const std::complex<double> w2 = w*w, w3 = w2*w, w4 = w2*w2;
-//     const double invSqrtPi = 1.0 / std::sqrt(M_PI);
-
-//     /* m = 0 */
-//     Ylm[4] = (3.0/16.0) * invSqrtPi
-//                     * (35.0*z4 - 30.0*z2 + 3.0);
-//     /* m = +1 */
-//     Ylm[5] = -(3.0/8.0) * std::sqrt(5.0/M_PI)
-//                     * (7.0*z3 - 3.0*z) * w;
-//     /* m = +2 */
-//     Ylm[6] = (3.0/8.0) * std::sqrt(5.0/(2.0*M_PI))
-//                     * (7.0*z2 - 1.0) * w2;
-//     /* m = +3 */
-//     Ylm[7] = -(3.0/8.0) * std::sqrt(35.0/M_PI) * z * w3;
-//     /* m = +4 */
-//     Ylm[8] = (3.0/16.0) * std::sqrt(35.0/(2.0*M_PI)) * w4;
-
-//     /* m < 0 via Y_l^{-m} = (-1)^m conj(Y_l^{+m}) */
-//     Ylm[3] = -std::conj(Ylm[5]);   // m = -1
-//     Ylm[2] =  std::conj(Ylm[6]);   // m = -2
-//     Ylm[1] = -std::conj(Ylm[7]);   // m = -3
-//     Ylm[0] =  std::conj(Ylm[8]);   // m = -4
-// }
-
-// void BondOrientationalOrderEstimator::Ylm_l6(
-//         const dVec &rhat, std::complex<double> Ylm[13])
-// {
-//     const double x = rhat[0], y = rhat[1], z = rhat[2];
-//     const double z2 = z*z, z3 = z2*z, z4 = z2*z2;
-//     const double z5 = z4*z, z6 = z3*z3;
-//     const std::complex<double> w(x, y);
-//     const std::complex<double> w2 = w*w, w3 = w2*w;
-//     const std::complex<double> w4 = w2*w2, w5 = w4*w, w6 = w3*w3;
-
-//     /* m = 0 */
-//     Ylm[6]  = (1.0/32.0) * std::sqrt(13.0/M_PI)
-//                     * (231.0*z6 - 315.0*z4 + 105.0*z2 - 5.0);
-//     /* m = +1 */
-//     Ylm[7]  = -(1.0/16.0) * std::sqrt(273.0/(2.0*M_PI))
-//                     * (33.0*z5 - 30.0*z3 + 5.0*z) * w;
-//     /* m = +2 */
-//     Ylm[8]  = (1.0/64.0) * std::sqrt(1365.0/M_PI)
-//                     * (33.0*z4 - 18.0*z2 + 1.0) * w2;
-//     /* m = +3 */
-//     Ylm[9]  = -(1.0/32.0) * std::sqrt(1365.0/M_PI)
-//                     * z * (11.0*z2 - 3.0) * w3;
-//     /* m = +4 */
-//     Ylm[10] = (21.0/32.0) * std::sqrt(13.0/(14.0*M_PI))
-//                     * (11.0*z2 - 1.0) * w4;
-//     /* m = +5 */
-//     Ylm[11] = -(3.0/32.0) * std::sqrt(1001.0/M_PI) * z * w5;
-//     /* m = +6 */
-//     Ylm[12] = (1.0/64.0) * std::sqrt(3003.0/M_PI) * w6;
-
-//     /* m < 0 via Y_l^{-m} = (-1)^m conj(Y_l^{+m}); for l = 6, m = 1..6
-//      * the signs alternate -, +, -, +, -, +. */
-//     Ylm[5] = -std::conj(Ylm[7]);    // m = -1
-//     Ylm[4] =  std::conj(Ylm[8]);    // m = -2
-//     Ylm[3] = -std::conj(Ylm[9]);    // m = -3
-//     Ylm[2] =  std::conj(Ylm[10]);   // m = -4
-//     Ylm[1] = -std::conj(Ylm[11]);   // m = -5
-//     Ylm[0] =  std::conj(Ylm[12]);   // m = -6
-// }
-
-
-// /*************************************************************************//**
-//  *  Find the kNN nearest neighbors of `positions[p_self]` and write their 
-//  *  unit-vector directions to `rhat`.
-// ******************************************************************************/
-// void BondOrientationalOrderEstimator::findKNearestNeighbors(
-//         int p_self,
-//         const std::vector<dVec> &positions,
-//         std::vector<int> &nbrs,
-//         std::vector<dVec> &rhat)
-// {
-//     const int N = positions.size();
-//     const dVec &r_i = positions[p_self];
-
-//     // Max-heap of (d2, j) keeping the kNN smallest d2 values.
-//     std::priority_queue<std::pair<double,int>> heap;
-
-//     for (int j = 0; j < N; ++j) {
-//         if (j == p_self) continue;
-//         // Minimum-image displacement.  The expression
-//         //     s -= L * floor(s/L + 0.5)
-//         // subtracts the integer multiple of L closest to s, which is the
-//         // branchless equivalent of "if s > L/2 subtract L; if s < -L/2 add L".
-//         dVec dr;
-//         for (int d = 0; d < NDIM; ++d) {
-//             double s = positions[j][d] - r_i[d];
-//             double L = path.boxPtr->side[d];
-//             s -= L * std::floor(s / L + 0.5);
-//             dr[d] = s;
-//         }
-//         double d2 = dot(dr, dr);
-//         if ((int)heap.size() < kNN) {
-//             heap.push({d2, j});
-//         } else if (d2 < heap.top().first) {
-//             heap.pop();
-//             heap.push({d2, j});
-//         }
-//     }
-
-//     // Drain heap and store the unit-vector directions.
-//     nbrs.resize(kNN);
-//     rhat.resize(kNN);
-//     for (int n = kNN - 1; n >= 0; --n) {
-//         double d2 = heap.top().first;
-//         int j = heap.top().second;
-//         heap.pop();
-//         nbrs[n] = j;
-//         const dVec &r_j = positions[j];
-//         double inv_d = 1.0 / std::sqrt(d2);
-//         for (int d = 0; d < NDIM; ++d) {
-//             double s = r_j[d] - r_i[d];
-//             double L = path.boxPtr->side[d];
-//             s -= L * std::floor(s / L + 0.5);
-//             rhat[n][d] = s * inv_d;
-//         }
-//     }
-// }
-
-
-// /*************************************************************************//**
-//  *  Compute the supercell-averaged q_l and qbar_l for l = 4, 6, for one
-//  *  configuration of N atomic positions (slice or centroid).
-// ******************************************************************************/
-// void BondOrientationalOrderEstimator::computeQValues(
-//         const std::vector<dVec> &positions,
-//         double &q4_avg, double &q6_avg,
-//         double &qbar4_avg, double &qbar6_avg)
-// {
-//     const int N = positions.size();
-
-//     /* Storage for per-particle q_lm values (l = 4 -> 9 cmplx,
-//      * l = 6 -> 13 cmplx). */
-//     std::vector<std::array<std::complex<double>, 9>>  qlm4(N);
-//     std::vector<std::array<std::complex<double>, 13>> qlm6(N);
-//     std::vector<std::vector<int>> all_nbrs(N);
-
-//     // Pass 1: for each i, find neighbors and accumulate q_lm(i).
-//     std::vector<int> nbrs;
-//     std::vector<dVec> rhat;
-//     std::complex<double> Y4[9], Y6[13];
-//     for (int i = 0; i < N; ++i) {
-//         findKNearestNeighbors(i, positions, nbrs, rhat);
-//         all_nbrs[i] = nbrs;
-//         for (int m = 0; m < 9;  ++m) qlm4[i][m] = 0.0;
-//         for (int m = 0; m < 13; ++m) qlm6[i][m] = 0.0;
-//         for (int n = 0; n < kNN; ++n) {
-//             Ylm_l4(rhat[n], Y4);
-//             Ylm_l6(rhat[n], Y6);
-//             for (int m = 0; m < 9;  ++m) qlm4[i][m] += Y4[m];
-//             for (int m = 0; m < 13; ++m) qlm6[i][m] += Y6[m];
-//         }
-//         for (int m = 0; m < 9;  ++m) qlm4[i][m] /= (double)kNN;
-//         for (int m = 0; m < 13; ++m) qlm6[i][m] /= (double)kNN;
-//     }
-
-//      // Pass 2: for each i, build qbar_lm(i) by averaging q_lm over
-//      //            particle i and its kNN neighbors (N_b+1 = 13 terms).
-//      //  Then sum the rotation-invariant magnitudes over the supercell and
-//      //  divide by N to get the average q_l and qbar_l.
-//     q4_avg = q6_avg = qbar4_avg = qbar6_avg = 0.0;
-//     const double pf4 = 4.0*M_PI / 9.0;        // 4 pi / (2 l + 1) for l=4
-//     const double pf6 = 4.0*M_PI / 13.0;       // 4 pi / (2 l + 1) for l=6
-//     for (int i = 0; i < N; ++i) {
-//         // qbar_lm: average q_lm over particle i AND its kNN neighbors
-//         std::array<std::complex<double>, 9>  qb4{};
-//         std::array<std::complex<double>, 13> qb6{};
-//         for (int m = 0; m < 9;  ++m) qb4[m] = qlm4[i][m];
-//         for (int m = 0; m < 13; ++m) qb6[m] = qlm6[i][m];
-//         for (int n = 0; n < kNN; ++n) {
-//             int j = all_nbrs[i][n];
-//             for (int m = 0; m < 9;  ++m) qb4[m] += qlm4[j][m];
-//             for (int m = 0; m < 13; ++m) qb6[m] += qlm6[j][m];
-//         }
-//         const double w = 1.0 / (double)(kNN + 1);
-//         for (int m = 0; m < 9;  ++m) qb4[m] *= w;
-//         for (int m = 0; m < 13; ++m) qb6[m] *= w;
-
-//         // sum_m |q_lm|^2 -> rotation invariants
-//         double s4 = 0, s6 = 0, sb4 = 0, sb6 = 0;
-//         for (int m = 0; m < 9;  ++m) s4  += std::norm(qlm4[i][m]);
-//         for (int m = 0; m < 13; ++m) s6  += std::norm(qlm6[i][m]);
-//         for (int m = 0; m < 9;  ++m) sb4 += std::norm(qb4[m]);
-//         for (int m = 0; m < 13; ++m) sb6 += std::norm(qb6[m]);
-
-//         q4_avg    += std::sqrt(pf4 * s4 );
-//         q6_avg    += std::sqrt(pf6 * s6 );
-//         qbar4_avg += std::sqrt(pf4 * sb4);
-//         qbar6_avg += std::sqrt(pf6 * sb6);
-//     }
-//     q4_avg    /= (double)N;
-//     q6_avg    /= (double)N;
-//     qbar4_avg /= (double)N;
-//     qbar6_avg /= (double)N;
-// }
-
-
-// /*************************************************************************//**
-//  *  Compute the centroid of the ring polymer that begins at slice 0,
-//  *  particle p, by walking path.next() for numTimeSlices steps and
-//  *  accumulating positions while unwrapping minimum-image jumps.
-// ******************************************************************************/
-// dVec BondOrientationalOrderEstimator::computeCentroid(int p)
-// {
-//     const int M = path.numTimeSlices;
-//     beadLocator bead = {0, p};
-//     dVec abs_pos = path(bead);
-//     dVec sum = abs_pos;
-//     for (int s = 1; s < M; ++s) {
-//         beadLocator bnext = path.next(bead);
-//         /* getSeparation returns r(bnext) - r(bead) under min-image */
-//         dVec dr = path.getSeparation(bnext, bead);
-//         abs_pos += dr;
-//         sum += abs_pos;
-//         bead = bnext;
-//     }
-//     sum /= (double)M;
-//     path.boxPtr->putInside(sum);   // wrap centroid back to [-L/2, L/2]
-//     return sum;
-// }
-
-
-// /*************************************************************************//**
-//  *  Accumulate one measurement of the 8 bond-orientational-order
-//  *  quantities into the estimator array.
-// ******************************************************************************/
-// void BondOrientationalOrderEstimator::accumulate()
-// {
-//     const int M = path.numTimeSlices;
-//     const int N = path.getTrueNumParticles();
-
-//     // PER-SLICE: average q_l, qbar_l over all M imaginary-time slices.
-//     // For each slice s we build an N-vector of positions, compute the
-//     // supercell-averaged q's, and accumulate.
-//     std::vector<dVec> positions(N);
-//     double q4_s = 0, q6_s = 0, qbar4_s = 0, qbar6_s = 0;
-//     for (int s = 0; s < M; ++s) {
-//         /* Gather positions at this slice.  In a closed-worm config
-//          * the number of beads per slice equals N. */
-//         for (int p = 0; p < N; ++p) {
-//             beadLocator bead = {s, p};
-//             positions[p] = path(bead);
-//         }
-//         double a4, a6, b4, b6;
-//         computeQValues(positions, a4, a6, b4, b6);
-//         q4_s    += a4;
-//         q6_s    += a6;
-//         qbar4_s += b4;
-//         qbar6_s += b6;
-//     }
-//     q4_s    /= (double)M;
-//     q6_s    /= (double)M;
-//     qbar4_s /= (double)M;
-//     qbar6_s /= (double)M;
-
-//     // CENTROID: trace each ring polymer to get the imag-time-averaged
-//     // position of each particle.
-//     std::vector<dVec> centroids(N);
-//     for (int p = 0; p < N; ++p)
-//         centroids[p] = computeCentroid(p);
-//     double q4_c, q6_c, qbar4_c, qbar6_c;
-//     computeQValues(centroids, q4_c, q6_c, qbar4_c, qbar6_c);
-
-//     // Push into the estimator array (8 columns).
-//     estimator(0) += q4_s;
-//     estimator(1) += q6_s;
-//     estimator(2) += qbar4_s;
-//     estimator(3) += qbar6_s;
-//     estimator(4) += q4_c;
-//     estimator(5) += q6_c;
-//     estimator(6) += qbar4_c;
-//     estimator(7) += qbar6_c;
-// }
 
 
 // ---------------------------------------------------------------------------

--- a/src/potential.cpp
+++ b/src/potential.cpp
@@ -74,6 +74,7 @@ REGISTER_INTERACTION_POTENTIAL(    "delta1D",    Delta1DPotential, GET_SETUP(), 
 REGISTER_INTERACTION_POTENTIAL( "lorentzian", LorentzianPotential, GET_SETUP(), setup.params["delta_width"].as<double>(), setup.params["delta_strength"].as<double>())
 REGISTER_INTERACTION_POTENTIAL(       "aziz",       AzizPotential, GET_SETUP(), setup.params["aziz_year"].as<int>(),setup.get_cell())
 REGISTER_INTERACTION_POTENTIAL(    "silvera",    SilveraPotential, GET_SETUP(), setup.get_cell())
+REGISTER_INTERACTION_POTENTIAL(  "patkowski",  PatkowskiPotential, GET_SETUP(), setup.get_cell())
 REGISTER_INTERACTION_POTENTIAL(       "H2LJ",                H2LJ, GET_SETUP(), setup.get_cell())
 REGISTER_INTERACTION_POTENTIAL(  "szalewicz",  SzalewiczPotential, GET_SETUP(), setup.get_cell())
 REGISTER_INTERACTION_POTENTIAL(   "harmonic",   HarmonicPotential, GET_SETUP(), setup.params["omega"].as<double>())
@@ -2044,7 +2045,7 @@ H2LJ::H2LJ(const Container *_boxPtr) : PotentialBase(), TabulatedPotential()
      // that is accurate to < 0.05% for 7 < x < 20.
      // TP 03/13/25.
 
-     double cutoff = L/2.0;
+     double cutoff = constants()->rc(); // Replaced L/2 with rc(). 26/06/30.
      double coeff[11] = {-6502.891909947514, 4179.6137878734, \
                          -1262.7540932141394, 231.31230978810987, \
                          -28.14200627626515, 2.3609501640706454, \
@@ -2138,6 +2139,186 @@ H2LJ::H2LJ(const Container *_boxPtr) : PotentialBase(), TabulatedPotential()
    return output;
  }
 
+
+//
+// Patkowski potential.
+// 
+
+// Constructor.
+PatkowskiPotential::PatkowskiPotential(const Container *_boxPtr)
+    : PotentialBase(), TabulatedPotential()
+{
+
+    cex[0] =  7.9181110538811;
+    cex[1] = -0.86728533815761;
+    csp[0] = -0.13759109019103;
+    csp[1] =  0.18174129593930;
+    csp[2] = -0.027161233180350;
+    csp[3] =  0.0010384349156326;
+
+    cdata[0] = -12.058168;   // C_6  ^000  (a.u.)
+    cdata[1] = -213.6;       // C_8  ^000  (a.u.)
+    cdata[2] = -4700.0;      // C_10 ^000  (a.u.)
+
+    // Unit conversions.
+    BohrPerAngstrom = 1.0 / 0.529177210544;
+    xK2au = 3.16669e-6;
+
+    // Parameters for the inner part of the potential.
+    r_inner_A = 0.7505;     // A
+    V_inner_K = 7.5528e+04; // K
+
+    // Placeholders.
+    extV.fill(0.0);
+    extdVdr.fill(0.0);
+    extd2Vdr2.fill(0.0);
+
+    // Lookup table.
+    const double Rm = 3.4623; // position of well minimum.
+    const double L = _boxPtr->maxSep;
+    initLookupTable(0.00005 * Rm, L);
+
+    // Tail correction.
+    const double rc = constants()->rc();
+    const double BPA = BohrPerAngstrom;
+
+    // C_n in K*A^n :  C_n^au is in Hartree*bohr^n (negative),
+    // divide by (xK2au*BPA^n) to get K*A^n (also negative).
+    const double C6_K  = cdata[0] / (xK2au * std::pow(BPA, 6.0));
+    const double C8_K  = cdata[1] / (xK2au * std::pow(BPA, 8.0));
+    const double C10_K = cdata[2] / (xK2au * std::pow(BPA, 10.0));
+
+    // int_{rc}^{inf} r^2*(C_n/r^n) dr = C_n/((n-3) rc^{n-3})
+    const double rc3 = rc*rc*rc;
+    const double rc5 = rc3*rc*rc;
+    const double rc7 = rc5*rc*rc;
+    tailV = 2.0 * M_PI * (C6_K/(3.0*rc3) + C8_K/(5.0*rc5) + C10_K/(7.0*rc7));
+}
+
+// Destructor.
+PatkowskiPotential::~PatkowskiPotential() { }
+
+inline __attribute__((always_inline))
+double PatkowskiPotential::valueV(const double r_A)
+{
+    // Handle the inner part of the potential.
+    if (r_A < EPS) return 0.0;
+    if (r_A < r_inner_A)  return V_inner_K;
+    
+    // Convert distance from A to Bohr radii.
+    const double R = r_A * BohrPerAngstrom;
+
+    // Short range part of potential.
+    const double vex = exp( 2.0 * (cex[0] + cex[1]*R) );
+    const double vsp = 2.0 * (csp[0] + R*(csp[1] + R*(csp[2] + R*csp[3])));
+    const double vshort = vex * vsp;
+
+    // Long range part of potential.
+    const double damp = -2.0 * cex[1];
+    const double dR   = damp * R;
+    const double iR  = 1.0 / R;
+    const double iR2 = iR * iR;
+    const double iR6 = iR2 * iR2 * iR2;
+    const double iR8 = iR6 * iR2;
+    const double iR10 = iR8 * iR2;
+    const double vlong_au = TT_f( 6, dR) * cdata[0] * iR6
+                          + TT_f( 8, dR) * cdata[1] * iR8
+                          + TT_f(10, dR) * cdata[2] * iR10;
+
+    return vshort + vlong_au / xK2au;
+}
+
+// First derivative.
+inline __attribute__((always_inline))
+double PatkowskiPotential::valuedVdr(const double r_A)
+{
+    // Handle the inner part of the potential.
+    if (r_A < EPS) return 0.0;
+    if (r_A < r_inner_A)  return 0.0;
+
+    const double R = r_A * BohrPerAngstrom;
+
+    // short-range value and first R-derivative
+    const double vex   = exp( 2.0 * (cex[0] + cex[1]*R) );
+    const double vsp   = 2.0 * (csp[0] + R*(csp[1] + R*(csp[2] + R*csp[3])));
+    const double vspp  = 2.0 * (csp[1] + R*(2.0*csp[2] + 3.0*csp[3]*R));
+    const double dvshort = vex * ( 2.0*cex[1] * vsp + vspp );
+
+    // long-range derivative (in a.u.)
+    const double damp = -2.0 * cex[1];
+    const double dR   = damp * R;
+    const double iR   = 1.0 / R;
+    const double iR6  = iR*iR*iR*iR*iR*iR;
+    const double iR7  = iR6*iR;
+    const double iR8  = iR7*iR;
+    const double iR9  = iR8*iR;
+    const double iR10 = iR9*iR;
+    const double iR11 = iR10*iR;
+
+    const double f6  = TT_f ( 6, dR);
+    const double f8  = TT_f ( 8, dR);
+    const double f10 = TT_f (10, dR);
+    const double df6  = TT_df( 6, dR);
+    const double df8  = TT_df( 8, dR);
+    const double df10 = TT_df(10, dR);
+
+    const double dvlong_au =
+          cdata[0] * (damp * df6  * iR6  -  6.0 * f6  * iR7 )
+        + cdata[1] * (damp * df8  * iR8  -  8.0 * f8  * iR9 )
+        + cdata[2] * (damp * df10 * iR10 - 10.0 * f10 * iR11);
+
+    // Convert at the end.
+    return ( dvshort + dvlong_au / xK2au ) * BohrPerAngstrom;
+}
+
+// Second derivative.
+inline __attribute__((always_inline))
+double PatkowskiPotential::valued2Vdr2(const double r_A)
+{
+    // Handle the inner part of the potential.
+    if (r_A < EPS) return 0.0;
+    if (r_A < r_inner_A)  return 0.0;
+
+    const double R = r_A * BohrPerAngstrom;
+
+    // short-range value and first two R-derivatives
+    const double vex    = exp( 2.0 * (cex[0] + cex[1]*R) );
+    const double vsp    = 2.0 * (csp[0] + R*(csp[1] + R*(csp[2] + R*csp[3])));
+    const double vspp   = 2.0 * (csp[1] + R*(2.0*csp[2] + 3.0*csp[3]*R));
+    const double vsppp  = 4.0*csp[2] + 12.0*csp[3]*R;       // vsp''(R)
+    const double a1     = 2.0 * cex[1];                     // exp argument's R-slope
+    const double d2vshort = vex * ( a1*a1 * vsp + 2.0*a1 * vspp + vsppp );
+
+    // long-range 2nd derivative (in a.u.)
+    const double damp  = -2.0 * cex[1];
+    const double damp2 = damp * damp;
+    const double dR    = damp * R;
+    const double iR    = 1.0 / R;
+    const double iR2   = iR * iR;
+    const double iR6   = iR2 * iR2 * iR2;
+    const double iR8   = iR6 * iR2;
+    const double iR10  = iR8 * iR2;
+    const double iR12  = iR10 * iR2;
+
+    auto longterm = [&](int n, double f, double df, double d2f, double iRnp2) {
+        // cdata_n / R^(n+2)  *  [ damp^2 * d2f - 2*n*damp * df + n(n+1) * f ]
+        double bracket = damp2 * d2f
+                       - 2.0 * static_cast<double>(n) * damp * df
+                       + static_cast<double>(n * (n + 1)) * f;
+        return bracket * iRnp2;
+    };
+
+    const double d2vlong_au =
+          cdata[0] * longterm( 6,
+              TT_f ( 6, dR), TT_df ( 6, dR), TT_d2f( 6, dR),  iR8 )
+        + cdata[1] * longterm( 8,
+              TT_f ( 8, dR), TT_df ( 8, dR), TT_d2f( 8, dR), iR10 )
+        + cdata[2] * longterm(10,
+              TT_f (10, dR), TT_df (10, dR), TT_d2f(10, dR), iR12 );
+
+    // K/bohr^2 -> K/A^2
+    return ( d2vshort + d2vlong_au / xK2au ) * BohrPerAngstrom * BohrPerAngstrom;
+}
 
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
There are a few things bundled together in this pull request, since they touch the same files.

**(1) Fix a merge bug from pull requests #45 and #46.** When the pull requests for the `BondOrientationalOrderEstimator` and the `FinalStateEffectsEstimator` were combined, the conflict resolution swapped private sections in the declarations of these classes. This caused the code to break. I've restored their classes to their original declarations and checked that the code builds and runs.

**(2) Addition of two potentials.** `PatkowskiPotential` is an isotropic hydrogen pair potential. `XeLJ` is a Lennard-Jones potential for xenon.

**(3) Tail correction for the Silvera potential.** `SilveraPotential`'s tail correction now uses `constants()->rc()` instead of `L/2`.
